### PR TITLE
Feat/post pages / 게시글 페이징 및 생성일 기준 내림차순 정렬 기능

### DIFF
--- a/src/main/java/com/example/newspeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newspeed/post/controller/PostController.java
@@ -35,10 +35,13 @@ public class PostController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
-    @GetMapping
-    public ResponseEntity<List<FindAllPostResponseDto>> findAllAPI() {
-
-        List<FindAllPostResponseDto> allPost = postService.findAllPost();
+    @GetMapping("/pages")
+    public ResponseEntity<List<FindAllPostResponseDto>> findAllAPI(
+            @RequestParam (defaultValue = "1") int page,
+            @RequestParam (defaultValue = "10") int size
+    )
+    {
+        List<FindAllPostResponseDto> allPost = postService.findAllPost(page, size);
 
         return new ResponseEntity<>(allPost, HttpStatus.OK);
     }

--- a/src/main/java/com/example/newspeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newspeed/post/controller/PostController.java
@@ -55,7 +55,9 @@ public class PostController {
     @PatchMapping("/{id}")
     public ResponseEntity<UpdatePostResponseDto> updatedPostAPI(@PathVariable Long id, @RequestBody PostRequestDto dto) {
 
-        UpdatePostResponseDto responseDto = postService.updatedPost(id, dto.getTitle(), dto.getContents(), dto.getImageUrl());
+        Long currentUserId = jwtTokenProvider.getUserIdFromSecurity();
+
+        UpdatePostResponseDto responseDto = postService.updatedPost(id, currentUserId, dto.getTitle(), dto.getContents(), dto.getImageUrl());
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
@@ -63,7 +65,9 @@ public class PostController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePostAPI(@PathVariable Long id, @RequestBody DeletePostRequestDto dto) {
 
-        postService.deletePost(id, dto.getPassword());
+        Long currentUserId = jwtTokenProvider.getUserIdFromSecurity();
+
+        postService.deletePost(id, currentUserId, dto.getPassword());
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/example/newspeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newspeed/post/controller/PostController.java
@@ -2,10 +2,7 @@ package com.example.newspeed.post.controller;
 
 
 import com.example.newspeed.global.common.JwtTokenProvider;
-import com.example.newspeed.post.dto.DeletePostRequestDto;
-import com.example.newspeed.post.dto.FindAllPostResponseDto;
-import com.example.newspeed.post.dto.PostRequestDto;
-import com.example.newspeed.post.dto.PostResponseDto;
+import com.example.newspeed.post.dto.*;
 import com.example.newspeed.post.service.PostService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,17 +45,17 @@ public class PostController {
 
     // 게시글 단건 조회 API
     @GetMapping("/{id}")
-    public ResponseEntity<FindAllPostResponseDto> findOneAPI(@PathVariable Long id) {
+    public ResponseEntity<FindOnePostResponseDto> findOneAPI(@PathVariable Long id) {
 
-        FindAllPostResponseDto findOnePost = postService.findOnePost(id);
+        FindOnePostResponseDto findOnePost = postService.findOnePost(id);
 
         return new ResponseEntity<>(findOnePost, HttpStatus.OK);
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<FindAllPostResponseDto> updatedPostAPI(@PathVariable Long id, @RequestBody PostRequestDto dto) {
+    public ResponseEntity<UpdatePostResponseDto> updatedPostAPI(@PathVariable Long id, @RequestBody PostRequestDto dto) {
 
-        FindAllPostResponseDto responseDto = postService.updatedPost(id, dto.getTitle(), dto.getContents(), dto.getImageUrl());
+        UpdatePostResponseDto responseDto = postService.updatedPost(id, dto.getTitle(), dto.getContents(), dto.getImageUrl());
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/src/main/java/com/example/newspeed/post/dto/FindAllPostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/FindAllPostResponseDto.java
@@ -13,15 +13,17 @@ public class FindAllPostResponseDto {
     private final String title;
     private final String contents;
     private final String imageUrl;
+    private final String userUrl;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public FindAllPostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public FindAllPostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.id = id;
         this.nickname = nickname;
         this.title = title;
         this.contents = contents;
         this.imageUrl = imageUrl;
+        this.userUrl = userUrl;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
@@ -29,10 +31,11 @@ public class FindAllPostResponseDto {
     public static FindAllPostResponseDto toPostDto(Post post) {
         return new FindAllPostResponseDto(
                 post.getId(),
-                "닉네임",  //post.getUser().getNickname(),
+                post.getUser().getNickname(),
                 post.getTitle(),
                 post.getContents(),
                 post.getImageUrl(),
+                post.getUserUrl(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );

--- a/src/main/java/com/example/newspeed/post/dto/FindOnePostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/FindOnePostResponseDto.java
@@ -2,6 +2,28 @@ package com.example.newspeed.post.dto;
 
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class FindOnePostResponseDto {
+
+    private final Long id;
+    private final String nickname;
+    private final String title;
+    private final String contents;
+    private final String imageUrl;
+    private final String userUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public FindOnePostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.title = title;
+        this.contents = contents;
+        this.imageUrl = imageUrl;
+        this.userUrl = userUrl;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
 }

--- a/src/main/java/com/example/newspeed/post/dto/UpdatePostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/UpdatePostResponseDto.java
@@ -2,6 +2,28 @@ package com.example.newspeed.post.dto;
 
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class UpdatePostResponseDto {
+
+    private final Long id;
+    private final String nickname;
+    private final String title;
+    private final String contents;
+    private final String imageUrl;
+    private final String userUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public UpdatePostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.title = title;
+        this.contents = contents;
+        this.imageUrl = imageUrl;
+        this.userUrl = userUrl;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
 }

--- a/src/main/java/com/example/newspeed/post/repository/PostRepository.java
+++ b/src/main/java/com/example/newspeed/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.example.newspeed.post.repository;
 
 import com.example.newspeed.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -11,5 +13,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     default Post findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
+
+    // 게시글 전체 조회 기능 페이징처리
+    Page<Post> findAll(Pageable pageable);
 
 }

--- a/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.example.newspeed.post.service;
 
+import com.example.newspeed.global.common.PasswordManager;
 import com.example.newspeed.global.common.SecurityConfig;
 import com.example.newspeed.post.dto.FindAllPostResponseDto;
 import com.example.newspeed.post.dto.FindOnePostResponseDto;
@@ -25,11 +26,13 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserService userService;
     private final SecurityConfig securityConfig;
+    private final PasswordManager passwordManager;
 
-    public PostService(PostRepository postRepository, UserService userService, SecurityConfig securityConfig) {
+    public PostService(PostRepository postRepository, UserService userService, SecurityConfig securityConfig, PasswordManager passwordManager) {
         this.postRepository = postRepository;
         this.userService = userService;
         this.securityConfig = securityConfig;
+        this.passwordManager = passwordManager;
     }
 
     @Transactional
@@ -93,23 +96,24 @@ public class PostService {
 
     // Post 게시글 수정 기능
     @Transactional
-    public UpdatePostResponseDto updatedPost(Long id, String title, String contents, String imageUrl) {
+    public UpdatePostResponseDto updatedPost(Long id, Long currentUserId, String title, String contents, String imageUrl) {
 
         Optional<Post> findById = postRepository.findById(id);
         Post post = findById.get();
 
-        if (title != null) {
-            post.setTitle(title);
-        }
+        if (currentUserId.equals(post.getUser().getId())) {
+            if (title != null) {
+                post.setTitle(title);
+            }
 
-        if (contents != null) {
-            post.setContents(contents);
-        }
+            if (contents != null) {
+                post.setContents(contents);
+            }
 
-        if (imageUrl != null) {
-            post.setImageUrl(imageUrl);
+            if (imageUrl != null) {
+                post.setImageUrl(imageUrl);
+            }
         }
-
         UpdatePostResponseDto responseDto = new UpdatePostResponseDto(
                 post.getId(),
                 post.getUser().getNickname(),
@@ -126,19 +130,18 @@ public class PostService {
 
     // 게시글 삭제 기능
     @Transactional
-    public void deletePost(Long id, String password) {
+    public void deletePost(Long id, Long currentUserId, String password) {
 
         // 입력받은 아이디로 Post 불러오기
         Post post = postRepository.findByIdOrElseThrow(id);
 
-        // 입력한 비밀번호와 유저 비밀번호가 같은지 검증
-        boolean checkPassword = securityConfig.passwordEncoder().matches(password, post.getUser().getPassword());
+        if (currentUserId.equals(post.getUser().getId())) {
+            // 입력한 비밀번호와 유저 비밀번호가 같은지 검증
+            passwordManager.validatePasswordMatchOrThrow(password, post.getUser().getPassword());
 
-        // 비밀번호가 같을 시 post를 삭제
-        if (checkPassword) {
             postRepository.delete(post);
-        }
 
+        }
     }
 }
 

--- a/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -2,7 +2,9 @@ package com.example.newspeed.post.service;
 
 import com.example.newspeed.global.common.SecurityConfig;
 import com.example.newspeed.post.dto.FindAllPostResponseDto;
+import com.example.newspeed.post.dto.FindOnePostResponseDto;
 import com.example.newspeed.post.dto.PostResponseDto;
+import com.example.newspeed.post.dto.UpdatePostResponseDto;
 import com.example.newspeed.post.entity.Post;
 import com.example.newspeed.post.repository.PostRepository;
 import com.example.newspeed.user.entity.User;
@@ -63,17 +65,18 @@ public class PostService {
 
     // 게시글 단건 조회 기능
     @Transactional
-    public FindAllPostResponseDto findOnePost(Long id) {
+    public FindOnePostResponseDto findOnePost(Long id) {
 
         // 레포지토리에서 생성한 기능을 사용
         Post post = postRepository.findByIdOrElseThrow(id);
 
-        FindAllPostResponseDto responseDto = new FindAllPostResponseDto(
+        FindOnePostResponseDto responseDto = new FindOnePostResponseDto(
                 id,
                 post.getUser().getNickname(),
                 post.getTitle(),
                 post.getContents(),
                 post.getImageUrl(),
+                post.getUserUrl(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );
@@ -90,7 +93,7 @@ public class PostService {
 
     // Post 게시글 수정 기능
     @Transactional
-    public FindAllPostResponseDto updatedPost(Long id, String title, String contents, String imageUrl) {
+    public UpdatePostResponseDto updatedPost(Long id, String title, String contents, String imageUrl) {
 
         Optional<Post> findById = postRepository.findById(id);
         Post post = findById.get();
@@ -107,12 +110,13 @@ public class PostService {
             post.setImageUrl(imageUrl);
         }
 
-        FindAllPostResponseDto responseDto = new FindAllPostResponseDto(
+        UpdatePostResponseDto responseDto = new UpdatePostResponseDto(
                 post.getId(),
                 post.getUser().getNickname(),
                 post.getTitle(),
                 post.getContents(),
                 post.getImageUrl(),
+                post.getUserUrl(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );

--- a/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -1,7 +1,6 @@
 package com.example.newspeed.post.service;
 
 import com.example.newspeed.global.common.PasswordManager;
-import com.example.newspeed.global.common.SecurityConfig;
 import com.example.newspeed.post.dto.FindAllPostResponseDto;
 import com.example.newspeed.post.dto.FindOnePostResponseDto;
 import com.example.newspeed.post.dto.PostResponseDto;
@@ -13,25 +12,27 @@ import com.example.newspeed.user.service.UserService;
 import jakarta.transaction.Transactional;
 
 
-
-import org.springframework.security.crypto.password.PasswordEncoder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 public class PostService {
 
     private final PostRepository postRepository;
     private final UserService userService;
-    private final SecurityConfig securityConfig;
     private final PasswordManager passwordManager;
 
-    public PostService(PostRepository postRepository, UserService userService, SecurityConfig securityConfig, PasswordManager passwordManager) {
+    public PostService(PostRepository postRepository, UserService userService, PasswordManager passwordManager) {
         this.postRepository = postRepository;
         this.userService = userService;
-        this.securityConfig = securityConfig;
         this.passwordManager = passwordManager;
     }
 
@@ -60,9 +61,20 @@ public class PostService {
     }
 
     @Transactional
-    public List<FindAllPostResponseDto> findAllPost() {
+    public List<FindAllPostResponseDto> findAllPost(int page, int size) {
 
-        return postRepository.findAll().stream().map(FindAllPostResponseDto::toPostDto).toList();
+        // 페이지 번호 1을 -> 0으로 변경하여 파라미터에 1입력 시 0번째 페이지 조회
+        page -= 1;
+
+        // 페이지 번호, 크기 지정 및 정렬 (생성 일자 기준으로 내림차순)
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+        // 레포지토리에서 생성한 게시글 전체 조회 페이징 기능
+        Page<Post> postPage = postRepository.findAll(pageable);
+
+        // 리스트로 반환
+        return postPage.stream().map(FindAllPostResponseDto::toPostDto).toList();
+
     }
 
 


### PR DESCRIPTION
게시글 페이징 및 생성일 기준 내림차순 정렬 기능입니다.


정렬을 생성일 기준으로 한 이유는 필수 구현 기능의 조건이 생성일 기준 정렬이기 때문입니다.


Postman 테스트 시 

/api/posts/pages?page=
(기본값인 0번 페이지와, 10개의 게시글이 반환됩니다.)
/api/posts/pages?page=2
(1번 페이지와, 기본값인 10개의 게시글이 반환됩니다.)
/api/posts/pages?page =3&size=5
(2번 페이지와, 5개의 게시글이 반환됩니다.)

등의 주소로 테스트 할 수 있습니다.