### PR TITLE
feat: 게시글 생성, 조회, 수정 시 게시글 좋아요 수 반환 기능

### DIFF
--- a/src/main/java/com/example/newspeed/post/dto/FindAllPostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/FindAllPostResponseDto.java
@@ -14,16 +14,27 @@ public class FindAllPostResponseDto {
     private final String contents;
     private final String imageUrl;
     private final String userUrl;
+    private final int postLikes;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public FindAllPostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public FindAllPostResponseDto(Long id,
+                                  String nickname,
+                                  String title,
+                                  String contents,
+                                  String imageUrl,
+                                  String userUrl,
+                                  int postLikes,
+                                  LocalDateTime createdAt,
+                                  LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.nickname = nickname;
         this.title = title;
         this.contents = contents;
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
+        this.postLikes = postLikes;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
@@ -36,6 +47,7 @@ public class FindAllPostResponseDto {
                 post.getContents(),
                 post.getImageUrl(),
                 post.getUserUrl(),
+                post.getPostLikes().size(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );

--- a/src/main/java/com/example/newspeed/post/dto/FindOnePostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/FindOnePostResponseDto.java
@@ -13,16 +13,27 @@ public class FindOnePostResponseDto {
     private final String contents;
     private final String imageUrl;
     private final String userUrl;
+    private final int postLikes;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public FindOnePostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public FindOnePostResponseDto(Long id,
+                                  String nickname,
+                                  String title,
+                                  String contents,
+                                  String imageUrl,
+                                  String userUrl,
+                                  int postLikes,
+                                  LocalDateTime createdAt,
+                                  LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.nickname = nickname;
         this.title = title;
         this.contents = contents;
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
+        this.postLikes = postLikes;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }

--- a/src/main/java/com/example/newspeed/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/PostResponseDto.java
@@ -1,9 +1,11 @@
 package com.example.newspeed.post.dto;
 
 import com.example.newspeed.post.entity.Post;
+import com.example.newspeed.post.entity.PostLikes;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class PostResponseDto {
@@ -14,16 +16,27 @@ public class PostResponseDto {
     private final String contents;
     private final String imageUrl;
     private final String userUrl;
+    private final int postLikes;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public PostResponseDto(Long id, Long userId, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public PostResponseDto(Long id,
+                           Long userId,
+                           String title,
+                           String contents,
+                           String imageUrl,
+                           String userUrl,
+                           int postLikes,
+                           LocalDateTime createdAt,
+                           LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.userId = userId;
         this.title = title;
         this.contents = contents;
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
+        this.postLikes = postLikes;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }

--- a/src/main/java/com/example/newspeed/post/dto/UpdatePostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/UpdatePostResponseDto.java
@@ -13,16 +13,27 @@ public class UpdatePostResponseDto {
     private final String contents;
     private final String imageUrl;
     private final String userUrl;
+    private final int postLikes;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public UpdatePostResponseDto(Long id, String nickname, String title, String contents, String imageUrl, String userUrl, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    public UpdatePostResponseDto(Long id,
+                                 String nickname,
+                                 String title,
+                                 String contents,
+                                 String imageUrl,
+                                 String userUrl,
+                                 int postLikes,
+                                 LocalDateTime createdAt,
+                                 LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.nickname = nickname;
         this.title = title;
         this.contents = contents;
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
+        this.postLikes = postLikes;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }

--- a/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -56,6 +56,7 @@ public class PostService {
                         savePost.getContents(),
                         savePost.getImageUrl(),
                         savePost.getUser().getUserUrl(),
+                        savePost.getPostLikes().size(),
                         savePost.getCreatedAt(),
                         savePost.getModifiedAt()
                 );
@@ -95,6 +96,7 @@ public class PostService {
                 post.getContents(),
                 post.getImageUrl(),
                 post.getUserUrl(),
+                post.getPostLikes().size(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );
@@ -146,6 +148,7 @@ public class PostService {
                 post.getContents(),
                 post.getImageUrl(),
                 post.getUserUrl(),
+                post.getPostLikes().size(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );


### PR DESCRIPTION
게시글 생성, 조회, 수정 시 게시글 좋아요 수 확인할 수 있도록 Dto 및 Service 수정했습니다.


`PostResponseDto` 
+ `postLikes`필드 추가, 동일하게 생성자 변경

`FindAllPostResponseDto`
+ `postLikes`필드 추가, 동일하게 생성자 변경
+ `toPostDto`기능 내부 생성자에 `post.getPostLikes().size()` 추가

`FindOnePostResponseDto`
+ `postLikes`필드 추가, 동일하게 생성자 변경

`UpdatePostResponseDto`
+ `postLikes`필드 추가, 동일하게 생성자 변경

`PostService`
+ `createPost`, `findOnePost`, `updatedPost`기능 변경된 Dto에 맞게 수정

