### PR TITLE
feat: 게시글 생성, 조회, 수정 시 게시글 댓글 수 반환 기능

### DIFF
--- a/src/main/java/com/example/newspeed/post/dto/FindAllPostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/FindAllPostResponseDto.java
@@ -15,6 +15,7 @@ public class FindAllPostResponseDto {
     private final String imageUrl;
     private final String userUrl;
     private final int postLikes;
+    private final int postComments;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -25,6 +26,7 @@ public class FindAllPostResponseDto {
                                   String imageUrl,
                                   String userUrl,
                                   int postLikes,
+                                  int postComments,
                                   LocalDateTime createdAt,
                                   LocalDateTime modifiedAt
     ) {
@@ -35,6 +37,7 @@ public class FindAllPostResponseDto {
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
         this.postLikes = postLikes;
+        this.postComments = postComments;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }
@@ -48,6 +51,7 @@ public class FindAllPostResponseDto {
                 post.getImageUrl(),
                 post.getUserUrl(),
                 post.getPostLikes().size(),
+                post.getComments().size(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );

--- a/src/main/java/com/example/newspeed/post/dto/FindOnePostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/FindOnePostResponseDto.java
@@ -14,6 +14,7 @@ public class FindOnePostResponseDto {
     private final String imageUrl;
     private final String userUrl;
     private final int postLikes;
+    private final int postComments;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -24,6 +25,7 @@ public class FindOnePostResponseDto {
                                   String imageUrl,
                                   String userUrl,
                                   int postLikes,
+                                  int postComments,
                                   LocalDateTime createdAt,
                                   LocalDateTime modifiedAt
     ) {
@@ -34,6 +36,7 @@ public class FindOnePostResponseDto {
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
         this.postLikes = postLikes;
+        this.postComments = postComments;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }

--- a/src/main/java/com/example/newspeed/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/PostResponseDto.java
@@ -1,11 +1,7 @@
 package com.example.newspeed.post.dto;
 
-import com.example.newspeed.post.entity.Post;
-import com.example.newspeed.post.entity.PostLikes;
 import lombok.Getter;
-
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 public class PostResponseDto {
@@ -17,6 +13,7 @@ public class PostResponseDto {
     private final String imageUrl;
     private final String userUrl;
     private final int postLikes;
+    private final int postComments;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -27,6 +24,7 @@ public class PostResponseDto {
                            String imageUrl,
                            String userUrl,
                            int postLikes,
+                           int postComments,
                            LocalDateTime createdAt,
                            LocalDateTime modifiedAt
     ) {
@@ -37,6 +35,7 @@ public class PostResponseDto {
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
         this.postLikes = postLikes;
+        this.postComments = postComments;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }

--- a/src/main/java/com/example/newspeed/post/dto/UpdatePostResponseDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/UpdatePostResponseDto.java
@@ -14,6 +14,7 @@ public class UpdatePostResponseDto {
     private final String imageUrl;
     private final String userUrl;
     private final int postLikes;
+    private final int postComments;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -24,6 +25,7 @@ public class UpdatePostResponseDto {
                                  String imageUrl,
                                  String userUrl,
                                  int postLikes,
+                                 int postComments,
                                  LocalDateTime createdAt,
                                  LocalDateTime modifiedAt
     ) {
@@ -34,6 +36,7 @@ public class UpdatePostResponseDto {
         this.imageUrl = imageUrl;
         this.userUrl = userUrl;
         this.postLikes = postLikes;
+        this.postComments = postComments;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
     }

--- a/src/main/java/com/example/newspeed/post/service/PostService.java
+++ b/src/main/java/com/example/newspeed/post/service/PostService.java
@@ -57,6 +57,7 @@ public class PostService {
                         savePost.getImageUrl(),
                         savePost.getUser().getUserUrl(),
                         savePost.getPostLikes().size(),
+                        savePost.getComments().size(),
                         savePost.getCreatedAt(),
                         savePost.getModifiedAt()
                 );
@@ -97,6 +98,7 @@ public class PostService {
                 post.getImageUrl(),
                 post.getUserUrl(),
                 post.getPostLikes().size(),
+                post.getComments().size(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );
@@ -149,6 +151,7 @@ public class PostService {
                 post.getImageUrl(),
                 post.getUserUrl(),
                 post.getPostLikes().size(),
+                post.getComments().size(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );


### PR DESCRIPTION
게시글 생성, 조회, 수정 시 게시글 댓글 수 확인할 수 있도록 Dto 및 Service 수정했습니다.


`PostResponseDto` 
+ `postComments`필드 추가, 동일하게 생성자 변경

`FindAllPostResponseDto`
+ `postComments`필드 추가, 동일하게 생성자 변경
+ `toPostDto`기능 내부 생성자에 `post.getComments().size()` 추가

`FindOnePostResponseDto`
+ `postComments`필드 추가, 동일하게 생성자 변경

`UpdatePostResponseDto`
+ `postComments`필드 추가, 동일하게 생성자 변경

`PostService`
+ `createPost`, `findOnePost`, `updatedPost`기능 변경된 Dto에 맞게 수정