### PR TITLE
feat: 게시글 예외처리 기능

### DIFF
--- a/src/main/java/com/example/newspeed/global/Enums/ErrorCode.java
+++ b/src/main/java/com/example/newspeed/global/Enums/ErrorCode.java
@@ -18,9 +18,12 @@ public enum ErrorCode {
 
     // 게시글 관련
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
-    BOARD_NOT_OWNED(HttpStatus.BAD_REQUEST, "본인의 게시글만 삭제할 수 있습니다."),
-    BOARD_NOT_EXISTING(HttpStatus.NO_CONTENT, "게시글이 존재하지 않습니다."),
+    POST_NOT_OWNED(HttpStatus.BAD_REQUEST, "본인의 게시글만 수정 및 삭제할 수 있습니다."),
     POST_NOT_CHANGE(HttpStatus.BAD_REQUEST, "변경할 내용을 입력해야 합니다."),
+    POST_NOT_TITLE(HttpStatus.BAD_REQUEST,"제목을 입력해야 합니다."),
+    POST_NOT_CONTENTS(HttpStatus.BAD_REQUEST,"내용을 입력해야 합니다."),
+    POST_NOT_IMAGE(HttpStatus.BAD_REQUEST,"이미지를 삽입해야 합니다."),
+    TITLE_LENGTH_OVER(HttpStatus.BAD_REQUEST, "제목은 255자까지 입력 가능합니다."),
 
     // 댓글 관련
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/newspeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newspeed/post/controller/PostController.java
@@ -4,6 +4,7 @@ package com.example.newspeed.post.controller;
 import com.example.newspeed.global.common.JwtTokenProvider;
 import com.example.newspeed.post.dto.*;
 import com.example.newspeed.post.service.PostService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,7 @@ public class PostController {
 
 
     @PostMapping
-    public ResponseEntity<PostResponseDto> createPostAPI(@RequestBody PostRequestDto dto) {
+    public ResponseEntity<PostResponseDto> createPostAPI(@RequestBody @Valid PostRequestDto dto) {
         // JwtTokenProvider를 통해 로그인 유저 ID 가져오기
         Long currentUserId = jwtTokenProvider.getUserIdFromSecurity();
 

--- a/src/main/java/com/example/newspeed/post/dto/PostRequestDto.java
+++ b/src/main/java/com/example/newspeed/post/dto/PostRequestDto.java
@@ -1,12 +1,18 @@
 package com.example.newspeed.post.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class PostRequestDto {
 
+    @NotBlank
     private final String title;
+
+    @NotBlank
     private final String contents;
+
+    @NotBlank
     private final String imageUrl;
 
     public PostRequestDto(String title, String contents, String imageUrl) {

--- a/src/main/java/com/example/newspeed/post/repository/PostRepository.java
+++ b/src/main/java/com/example/newspeed/post/repository/PostRepository.java
@@ -4,21 +4,14 @@ import com.example.newspeed.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // Optional 처리를 위해 Repository에 default 기능 생성
-    default Post findByIdOrElseThrow(Long id) {
-        return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-    }
-
-
     List<Post> findAllByCreatedAtBetweenOrderByModifiedAtDesc(LocalDateTime start, LocalDateTime end);
+
     // 게시글 전체 조회 기능 페이징처리
     Page<Post> findAll(Pageable pageable);
 


### PR DESCRIPTION
게시글 CRUD API사용 시 발생할 수 있는 예외를 처리하는 기능입니다.

처리한 예외 목록은 다음과 같습니다.

Param을 사용하는 모든 기능

- [x] 게시글 접근 시 잘못된 Param값을 입력한 경우 (존재하지 않는 게시글 조회 시도) NOT_FOUND반환

- [x]  게시글 생성 시 제목을 입력하지 않은 경우 BAD_REQUEST반환
    - [x]  게시글 생성 시 제목의 길이가 제한 값을 초과한 경우 BAD_REQUEST반환
- [x]  게시글 생성 시 내용을 입력하지 않은 경우 BAD_REQUEST반환
- [x]  게시글 생성 시 이미지를 삽입하지 않은 경우 BAD_REQUEST반환
- [x]  게시글 단건 조회 기능의 예외처리
    - [x]  게시글 단건 조회 시 잘못된 Param값을 입력한 경우 (존재하지 않는 게시글 조회 시도) NOT_FOUND반환
- [x]  게시글 수정 기능의 예외처리
    - [x]  작성자가 아닌 다른 사용자가 게시물 수정을 시도하는 경우 BAD_REQUEST반환
    - [x]  게시글 수정 시 변경된 값이 없는 경우 BAD_REQUEST반환
- [x]  게시글 삭제 기능의 예외처리
    - [x]  작성자가 아닌 다른 사용자가 게시물 삭제를 시도하는 경우 BAD_REQUEST반환
    - [x]  게시글 삭제 시 잘못된 비밀번호를 입력한 경우 BAD_REQUEST반환